### PR TITLE
fix: remove libs from extensions, fix release note new line

### DIFF
--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -50,7 +50,7 @@ namespace :package do
   desc "Install gems to local directory"
   task :bundle_install do
     if RUBY_VERSION !~ /^#{RUBY_MAJOR_VERSION}\.#{RUBY_MINOR_VERSION}\./
-      abort "You can only 'bundle install' using Ruby #{RUBY_VERSION}, because that's what Traveling Ruby uses."
+      abort "You can only 'bundle install' using Ruby #{TRAVELING_RB_VERSION}, because that's what Traveling Ruby uses. \n You are using Ruby #{RUBY_VERSION}."
     end
     sh "rm -rf build/tmp"
     sh "mkdir -p build/tmp"
@@ -198,6 +198,9 @@ def remove_unnecessary_files package_dir
   sh "find #{package_dir}/lib/vendor/ruby/*/gems -name '*.o' | xargs rm -f"
   sh "find #{package_dir}/lib/vendor/ruby/*/gems -name '*.so' | xargs rm -f"
   sh "find #{package_dir}/lib/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f"
+  sh "find #{package_dir}/lib/vendor/ruby/*/extensions -name '*.o' | xargs rm -f"
+  sh "find #{package_dir}/lib/vendor/ruby/*/extensions -name '*.so' | xargs rm -f"
+  sh "find #{package_dir}/lib/vendor/ruby/*/extensions -name '*.bundle' | xargs rm -f"
 
   # Remove Java files. They're only used for JRuby support"
   sh "find #{package_dir}/lib/vendor/ruby -name '*.java' | xargs rm -f"

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -20,6 +20,7 @@ task :generate_release_notes, [:tag] do | t, args |
   release_notes_content = release_notes_content.gsub("<PACKAGE_VERSION>", VERSION)
   File.open(RELEASE_NOTES_PATH, "w") do |file|
     file << release_notes_content
+    file << "\n\n"
     file << readme_content
   end
 end


### PR DESCRIPTION
aarch64 build had x86_64 binaries in it
ensure package tells you the traveling-ruby version